### PR TITLE
Various changes to make navigation nicer

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -122,7 +122,7 @@ module.exports = function (eleventyConfig) {
       }
     });
 
-    return [...courseSet];
+    return [...courseSet].sort();
   });
 
   eleventyConfig.addCollection('ibCourseList', function (collection) {
@@ -133,7 +133,7 @@ module.exports = function (eleventyConfig) {
       }
     });
 
-    return [...courseSet];
+    return [...courseSet].sort();
   });
 
   eleventyConfig.addCollection('iiCourseList', function (collection) {
@@ -144,7 +144,7 @@ module.exports = function (eleventyConfig) {
       }
     });
 
-    return [...courseSet];
+    return [...courseSet].sort();
   });
 
   eleventyConfig.addCollection('tagList', function (collection) {

--- a/src/includes/posts-list.njk
+++ b/src/includes/posts-list.njk
@@ -2,21 +2,24 @@
   {% for post in postslist %}
     <li class="post-list__item">
       <h1 class="post-list__title">
-        <a  href="{{ post.url | url }}">{{ post.data.title | md | safe }}</a>
+        <a  href="{{ post.url | url }}" target="_blank">{{ post.data.title | md | safe }}</a>
       </h1>
       <div class="post__details">
           <div class="post-list__tags">
             {% set courseUrl %}/courses/{{ post.data.course }}/{% endset %}
-            <a href="{{ courseUrl | url }}">{{ post.data.course }}</a>
+            <a href="{{ courseUrl | url }}" target="_blank">{{ post.data.course }}</a>
+            <br />
+            {% set yearUrl %}/part-{{ post.data.course_year | lower }}//{{ post.data.year }}/{% endset %}
+            <a href="{{ yearUrl | url }}" target="_blank">Part {{ post.data.course_year }}, {{ post.data.year }}</a>
           </div>
-          Part {{ post.data.course_year }}, {{ post.data.year }}
       </div>
 
       <main class="post__content">
+    
         {{ post.templateContent | safe }}
       </main>
 
-      <a class="post-list__read-more" href="{{ post.url | url }}">comment</a>
+      <a class="post-list__read-more" href="{{ post.url | url }}" target="_blank">comment</a>
     </li>
   {% endfor %}
 </ul>
@@ -28,10 +31,12 @@
       <div>
         <div class="post-list__tags">
           {% set courseUrl %}/courses/{{ course }}/{% endset %}
-          <a href="{{ courseUrl | url }}">{{ course }}</a>
+          <a href="{{ courseUrl | url }}" target="_blank">{{ course }}</a>
+          <br />
+          {% set yearUrl %}/part-{{ course_year | lower }}//{{ year }}/{% endset %}
+          <a href="{{ yearUrl | url }}" target="_blank">{{ year }}</a>
         </div>
       </div>
-      {{ year }}
     </div>
   </header>
 

--- a/src/includes/posts-list.njk
+++ b/src/includes/posts-list.njk
@@ -8,7 +8,7 @@
           <div class="post-list__tags">
             {% set courseUrl %}/courses/{{ post.data.course }}/{% endset %}
             <a href="{{ courseUrl | url }}" target="_blank">{{ post.data.course }}</a>
-            <br />
+            <span>|</span>
             {% set yearUrl %}/part-{{ post.data.course_year | lower }}//{{ post.data.year }}/{% endset %}
             <a href="{{ yearUrl | url }}" target="_blank">Part {{ post.data.course_year }}, {{ post.data.year }}</a>
           </div>
@@ -32,7 +32,7 @@
         <div class="post-list__tags">
           {% set courseUrl %}/courses/{{ course }}/{% endset %}
           <a href="{{ courseUrl | url }}" target="_blank">{{ course }}</a>
-          <br />
+          <span>|</span>
           {% set yearUrl %}/part-{{ course_year | lower }}//{{ year }}/{% endset %}
           <a href="{{ yearUrl | url }}" target="_blank">{{ year }}</a>
         </div>

--- a/src/index.md
+++ b/src/index.md
@@ -10,3 +10,4 @@ An archive of questions from the [Cambridge Mathematics Tripos](https://www.math
 {% set latestComments = '50' %}
 {% include "tripos-comments.njk" %}
 
+*For older comments, see [GitHub discussions](https://github.com/tripos-education/maths-tripos-questions/discussions).*

--- a/src/layouts/post.njk
+++ b/src/layouts/post.njk
@@ -9,6 +9,7 @@ layout: base.njk
       <div class="post-list__tags">
         {% set courseUrl %}/courses/{{ course }}/{% endset %}
         <a href="{{ courseUrl | url }}" target="_blank">{{ course }}</a>
+	<span>|</span>
      {% set yearUrl %}/part-{{ course_year | lower }}/{{ year }}/{% endset %}
       <a href="{{ yearUrl | url}}" target="_blank">Part {{ course_year }}, {{ year }}</a>
       </div>

--- a/src/layouts/post.njk
+++ b/src/layouts/post.njk
@@ -8,18 +8,19 @@ layout: base.njk
     <div class="post__details">
       <div class="post-list__tags">
         {% set courseUrl %}/courses/{{ course }}/{% endset %}
-        <a href="{{ courseUrl | url }}">{{ course }}</a>
+        <a href="{{ courseUrl | url }}" target="_blank">{{ course }}</a>
+     {% set yearUrl %}/part-{{ course_year | lower }}/{{ year }}/{% endset %}
+      <a href="{{ yearUrl | url}}" target="_blank">Part {{ course_year }}, {{ year }}</a>
       </div>
-      Part {{ course_year }}, {{ year }}
     </div>
   </header>
 
   <main class="post__content">
-    {{ content | safe }}
+    {{ content | safe }} 
   </main>
   
   {% set editUrl %}https://github.com/tripos-education/maths-tripos-questions/blob/master/src/part-{{ course_year | lower }}/{{ year }}-{{ question_number }}.md{% endset %}
-  <div><i>Typos? Please <a href="{{ editUrl | url }}">submit corrections to this page on GitHub.</a></i></div>
+  <div><i>Typos? Please <a href="{{ editUrl | url }}" target="_blank">submit corrections to this page on GitHub.</a></i></div>
 
   {% set latestComments = '0' %}
   {% include "tripos-comments.njk" %}


### PR DESCRIPTION
1. First commit changes the course list to be alphabetically ordered. The random ordering annoys me each time I use the site...
2. Second commit makes the year tag of each question link back to the list of questions from that year, and *also* changes various links to open in a new tab (on post list pages, and the links to post list pages on questions). Imo this gives better UX, especially since post list pages can take a good few seconds to load.
3. Third commit adds a link to GitHub discussions on the home page itself (#48 made me think this could be a good nav improvement)