### PR TITLE
Separate current courses from old courses

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -127,8 +127,8 @@ module.exports = function (eleventyConfig) {
     // collection of current courses for this part
     let currentSet = new Set();
     eleventyConfig.addCollection(triposPart+'Current', function (collection) {
-      collection.getFilteredByTag("part-"+triposPart, currentYear).forEach(function (item) {
-        if ('course' in item.data) {
+      collection.getFilteredByTag("part-"+triposPart,currentYear).forEach(function (item) {
+        if ('course' in item.data && item.data.year == currentYear) {
           currentSet.add(item.data.course)
         }
       });
@@ -136,13 +136,8 @@ module.exports = function (eleventyConfig) {
     });
     
     // collection of discontinued courses for this part
-    let discontinuedSet = new Set();
-    for (const course of courseSet) {
-      if (!currentSet.has(course)) {
-        discontinuedSet.add(course);
-      }
-    }
     eleventyConfig.addCollection(triposPart+'Old', function (collection) {
+      let discontinuedSet = new Set([...courseSet].filter(x => !currentSet.has(x)));
       return [...discontinuedSet].sort();
     });    
   }

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -95,58 +95,58 @@ module.exports = function (eleventyConfig) {
     return array.slice(0, n);
   });
 
-  const yearList = Array.from(new Array(21), (x, i) => String(i + 2001));
+  const earliestYear = 2001;
+  const currentYear = 2021; // easily visible to update each year; could obtain by searching posts instead?
+  const yearList = Array.from(new Array(1+currentYear-earliestYear), (x, i) => String(i + earliestYear));
+  const triposPartList = ["ia","ib","ii"];
 
   eleventyConfig.addCollection('yearList', function (collection) {
     // return [...new Set(collection.getFilteredByTag("part-ia").map(post => String(post.data.year)))]
     return yearList
   });
-
-  for (const year of yearList) {
-    eleventyConfig.addCollection("ia-" + year, collection => {
-      return collection.getFilteredByTags("part-ia", year)
-    })
-    eleventyConfig.addCollection("ib-" + year, collection => {
-      return collection.getFilteredByTags("part-ib", year)
-    })
-    eleventyConfig.addCollection("ii-" + year, collection => {
-      return collection.getFilteredByTags("part-ii", year)
-    })
+  
+  for (const triposPart of triposPartList) {
+    // questions by year + part
+    for (const year of yearList) {
+      eleventyConfig.addCollection(triposPart + "-" + year, collection => {
+        return collection.getFilteredByTags("part-"+triposPart, year)
+      }     
+    }
+    
+    // collection of all courses for this part
+    let courseSet = new Set();
+    eleventyConfig.addCollection(triposPart+'CourseList', function (collection) {
+      collection.getFilteredByTag("part-"+triposPart).forEach(function (item) {
+        if ('course' in item.data) {
+          courseSet.add(item.data.course)
+        }
+      });
+      return [...courseSet].sort();
+    });
+    
+    // collection of current courses for this part
+    let currentSet = new Set();
+    eleventyConfig.addCollection(triposPart+'Current', function (collection) {
+      collection.getFilteredByTag("part-"+triposPart, currentYear).forEach(function (item) {
+        if ('course' in item.data) {
+          currentSet.add(item.data.course)
+        }
+      });
+      return [...currentSet].sort();
+    });
+    
+    // collection of discontinued courses for this part
+    let discontinuedSet = new Set();
+    for (const course of courseSet) {
+      if (!currentSet.has(course)) {
+        discontinuedSet.add(course);
+      }
+    }
+    eleventyConfig.addCollection(triposPart+'Old', function (collection) {
+      return [...discontinuedSet].sort();
+    });    
   }
-
-  eleventyConfig.addCollection('iaCourseList', function (collection) {
-    let courseSet = new Set();
-    collection.getFilteredByTag("part-ia").forEach(function (item) {
-      if ('course' in item.data) {
-        courseSet.add(item.data.course)
-      }
-    });
-
-    return [...courseSet].sort();
-  });
-
-  eleventyConfig.addCollection('ibCourseList', function (collection) {
-    let courseSet = new Set();
-    collection.getFilteredByTag("part-ib").forEach(function (item) {
-      if ('course' in item.data) {
-        courseSet.add(item.data.course)
-      }
-    });
-
-    return [...courseSet].sort();
-  });
-
-  eleventyConfig.addCollection('iiCourseList', function (collection) {
-    let courseSet = new Set();
-    collection.getFilteredByTag("part-ii").forEach(function (item) {
-      if ('course' in item.data) {
-        courseSet.add(item.data.course)
-      }
-    });
-
-    return [...courseSet].sort();
-  });
-
+  
   eleventyConfig.addCollection('tagList', function (collection) {
     let tagSet = new Set();
     collection.getAll().forEach(function (item) {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -109,8 +109,8 @@ module.exports = function (eleventyConfig) {
     // questions by year + part
     for (const year of yearList) {
       eleventyConfig.addCollection(triposPart + "-" + year, collection => {
-        return collection.getFilteredByTags("part-"+triposPart, year)
-      }     
+        return collection.getFilteredByTags("part-"+triposPart, year);
+      });
     }
     
     // collection of all courses for this part

--- a/src/ia.njk
+++ b/src/ia.njk
@@ -7,14 +7,18 @@ description: "Part IA questions"
 
 <h1>Part IA</h1>
 
-<div class="tags">
-  {% include "ia-course-list.njk" %}
-</div>
-
+<h3>By Year</h3>
 <div class="tags">
   {% set courseYear = 'part-ia' %}
   {% include "year-list.njk" %}
 </div>
+
+<h3>By Course</h3>
+<div class="tags">
+  {% include "ia-course-list.njk" %}
+</div>
+
+
 
 {% set latestComments = '0' %}
 {% include "tripos-comments.njk" %}

--- a/src/ib.njk
+++ b/src/ib.njk
@@ -7,13 +7,15 @@ description: "Part IB questions"
 
 <h1>Part IB</h1>
 
-<div class="tags">
-  {% include "ib-course-list.njk" %}
-</div>
-
+<h3>By Year</h3>
 <div class="tags">
   {% set courseYear = 'part-ib' %}
   {% include "year-list.njk" %}
+</div>
+
+<h3>By Course</h3>
+<div class="tags">
+  {% include "ib-course-list.njk" %}
 </div>
 
 {% set latestComments = '0' %}

--- a/src/ii.njk
+++ b/src/ii.njk
@@ -7,13 +7,15 @@ description: "Part II questions"
 
 <h1>Part II</h1>
 
-<div class="tags">
-  {% include "ii-course-list.njk" %}
-</div>
-
+<h3>By Year</h3>
 <div class="tags">
   {% set courseYear = 'part-ii' %}
   {% include "year-list.njk" %}
+</div>
+
+<h3>By Course</h3>
+<div class="tags">
+  {% include "ii-course-list.njk" %}
 </div>
 
 {% set latestComments = '0' %}

--- a/src/includes/ia-course-list.njk
+++ b/src/includes/ia-course-list.njk
@@ -1,4 +1,12 @@
-{% for course in collections.iaCourseList %}
+<h4>Current</h4>
+{% for course in collections.iaCurrent %}
+  {% set courseUrl %}/courses/{{ course }}/{% endset %}
+
+  <a href="{{ courseUrl | url }}" class="post-tag">{{ course }}</a>
+
+{% endfor %}
+<h4>Discontinued</h4>
+{% for course in collections.iaOld %}
   {% set courseUrl %}/courses/{{ course }}/{% endset %}
 
   <a href="{{ courseUrl | url }}" class="post-tag">{{ course }}</a>

--- a/src/includes/ib-course-list.njk
+++ b/src/includes/ib-course-list.njk
@@ -1,4 +1,12 @@
-{% for course in collections.ibCourseList %}
+<h4>Current</h4>
+{% for course in collections.ibCurrent %}
+  {% set courseUrl %}/courses/{{ course }}/{% endset %}
+
+  <a href="{{ courseUrl | url }}" class="post-tag">{{ course }}</a>
+
+{% endfor %}
+<h4>Discontinued</h4>
+{% for course in collections.ibOld %}
   {% set courseUrl %}/courses/{{ course }}/{% endset %}
 
   <a href="{{ courseUrl | url }}" class="post-tag">{{ course }}</a>

--- a/src/includes/ii-course-list.njk
+++ b/src/includes/ii-course-list.njk
@@ -1,4 +1,12 @@
-{% for course in collections.iiCourseList %}
+<h4>Current</h4>
+{% for course in collections.iiCurrent %}
+  {% set courseUrl %}/courses/{{ course }}/{% endset %}
+
+  <a href="{{ courseUrl | url }}" class="post-tag">{{ course }}</a>
+
+{% endfor %}
+<h4>Discontinued</h4>
+{% for course in collections.iiOld %}
   {% set courseUrl %}/courses/{{ course }}/{% endset %}
 
   <a href="{{ courseUrl | url }}" class="post-tag">{{ course }}</a>


### PR DESCRIPTION
Thing to do the thing in the title. I.e. resolve #186.
It took a few goes to get the collection generation code right - for some reason even though I filtered by year, initially the 'current courses' collections still contained all the courses.
It works now though, and I've also rearranged the tripos part pages because otherwise they looked weird with just headings for current vs discontinued courses.