### PR TITLE
Correct duplicate part ii courses

### DIFF
--- a/src/part-ii/2017-145.md
+++ b/src/part-ii/2017-145.md
@@ -1,11 +1,11 @@
 ---
-course: Topics In Analysis
+course: Topics in Analysis
 course_year: II
 question_number: 145
 tags:
 - II
 - '2017'
-- Topics In Analysis
+- Topics in Analysis
 title: 'Paper 2, Section I, F '
 year: 2017
 ---

--- a/src/part-ii/2017-146.md
+++ b/src/part-ii/2017-146.md
@@ -1,11 +1,11 @@
 ---
-course: Topics In Analysis
+course: Topics in Analysis
 course_year: II
 question_number: 146
 tags:
 - II
 - '2017'
-- Topics In Analysis
+- Topics in Analysis
 title: 'Paper 4, Section I, F '
 year: 2017
 ---

--- a/src/part-ii/2017-147.md
+++ b/src/part-ii/2017-147.md
@@ -1,12 +1,12 @@
 ---
-course: Topics In Analysis
+course: Topics in Analysis
 course_year: II
 question_number: 147
 tags:
 - II
 - '2017'
-- Topics In Analysis
-title: 'Paper 1, Section I, $2 F$ '
+- Topics in Analysis
+title: 'Paper 1, Section I, 2F '
 year: 2017
 ---
 

--- a/src/part-ii/2017-148.md
+++ b/src/part-ii/2017-148.md
@@ -1,12 +1,12 @@
 ---
-course: Topics In Analysis
+course: Topics in Analysis
 course_year: II
 question_number: 148
 tags:
 - II
 - '2017'
-- Topics In Analysis
-title: 'Paper 3, Section I, $2 F$ '
+- Topics in Analysis
+title: 'Paper 3, Section I, 2F'
 year: 2017
 ---
 

--- a/src/part-ii/2017-149.md
+++ b/src/part-ii/2017-149.md
@@ -1,11 +1,11 @@
 ---
-course: Topics In Analysis
+course: Topics in Analysis
 course_year: II
 question_number: 149
 tags:
 - II
 - '2017'
-- Topics In Analysis
+- Topics in Analysis
 title: 'Paper 2, Section II, F '
 year: 2017
 ---

--- a/src/part-ii/2017-150.md
+++ b/src/part-ii/2017-150.md
@@ -1,12 +1,12 @@
 ---
-course: Topics In Analysis
+course: Topics in Analysis
 course_year: II
 question_number: 150
 tags:
 - II
 - '2017'
-- Topics In Analysis
-title: 'Paper 4, Section II, $11 F$ '
+- Topics in Analysis
+title: 'Paper 4, Section II, 11F'
 year: 2017
 ---
 

--- a/src/part-ii/2017-34.md
+++ b/src/part-ii/2017-34.md
@@ -1,11 +1,11 @@
 ---
-course: Coding \& Cryptography
+course: Coding & Cryptography
 course_year: II
 question_number: 34
 tags:
 - II
 - '2017'
-- Coding \& Cryptography
+- Coding & Cryptography
 title: 'Paper 1, Section I, G '
 year: 2017
 ---

--- a/src/part-ii/2017-34.md
+++ b/src/part-ii/2017-34.md
@@ -1,11 +1,11 @@
 ---
-course: Coding & Cryptography
+course: Coding and Cryptography
 course_year: II
 question_number: 34
 tags:
 - II
 - '2017'
-- Coding & Cryptography
+- Coding and Cryptography
 title: 'Paper 1, Section I, G '
 year: 2017
 ---

--- a/src/part-ii/2017-35.md
+++ b/src/part-ii/2017-35.md
@@ -1,12 +1,12 @@
 ---
-course: Coding \& Cryptography
+course: Coding and Cryptography
 course_year: II
 question_number: 35
 tags:
 - II
 - '2017'
-- Coding \& Cryptography
-title: 'Paper 2, Section $I$, G '
+- Coding and Cryptography
+title: 'Paper 2, Section I, G '
 year: 2017
 ---
 

--- a/src/part-ii/2017-36.md
+++ b/src/part-ii/2017-36.md
@@ -1,11 +1,11 @@
 ---
-course: Coding \& Cryptography
+course: Coding and Cryptography
 course_year: II
 question_number: 36
 tags:
 - II
 - '2017'
-- Coding \& Cryptography
+- Coding and Cryptography
 title: 'Paper 3, Section I, G '
 year: 2017
 ---

--- a/src/part-ii/2017-37.md
+++ b/src/part-ii/2017-37.md
@@ -1,11 +1,11 @@
 ---
-course: Coding \& Cryptography
+course: Coding and Cryptography
 course_year: II
 question_number: 37
 tags:
 - II
 - '2017'
-- Coding \& Cryptography
+- Coding and Cryptography
 title: 'Paper 4, Section I, G '
 year: 2017
 ---

--- a/src/part-ii/2017-38.md
+++ b/src/part-ii/2017-38.md
@@ -1,11 +1,11 @@
 ---
-course: Coding \& Cryptography
+course: Coding and Cryptography
 course_year: II
 question_number: 38
 tags:
 - II
 - '2017'
-- Coding \& Cryptography
+- Coding and Cryptography
 title: 'Paper 1, Section II, G '
 year: 2017
 ---

--- a/src/part-ii/2017-39.md
+++ b/src/part-ii/2017-39.md
@@ -1,11 +1,11 @@
 ---
-course: Coding \& Cryptography
+course: Coding and Cryptography
 course_year: II
 question_number: 39
 tags:
 - II
 - '2017'
-- Coding \& Cryptography
+- Coding and Cryptography
 title: 'Paper 2, Section II, G '
 year: 2017
 ---

--- a/src/part-ii/2018-34.md
+++ b/src/part-ii/2018-34.md
@@ -1,11 +1,11 @@
 ---
-course: Coding \& Cryptography
+course: Coding and Cryptography
 course_year: II
 question_number: 34
 tags:
 - II
 - '2018'
-- Coding \& Cryptography
+- Coding and Cryptography
 title: 'Paper 4, Section I, H '
 year: 2018
 ---

--- a/src/part-ii/2018-35.md
+++ b/src/part-ii/2018-35.md
@@ -1,11 +1,11 @@
 ---
-course: Coding \& Cryptography
+course: Coding and Cryptography
 course_year: II
 question_number: 35
 tags:
 - II
 - '2018'
-- Coding \& Cryptography
+- Coding and Cryptography
 title: 'Paper 3, Section $I$, H '
 year: 2018
 ---

--- a/src/part-ii/2018-36.md
+++ b/src/part-ii/2018-36.md
@@ -1,12 +1,12 @@
 ---
-course: Coding \& Cryptography
+course: Coding and Cryptography
 course_year: II
 question_number: 36
 tags:
 - II
 - '2018'
-- Coding \& Cryptography
-title: 'Paper 2, Section $I$, H '
+- Coding and Cryptography
+title: 'Paper 2, Section I, H '
 year: 2018
 ---
 

--- a/src/part-ii/2018-37.md
+++ b/src/part-ii/2018-37.md
@@ -1,12 +1,12 @@
 ---
-course: Coding \& Cryptography
+course: Coding and Cryptography
 course_year: II
 question_number: 37
 tags:
 - II
 - '2018'
-- Coding \& Cryptography
-title: 'Paper 1, Section $\mathbf{I}$, H '
+- Coding and Cryptography
+title: 'Paper 1, Section I, H '
 year: 2018
 ---
 

--- a/src/part-ii/2018-38.md
+++ b/src/part-ii/2018-38.md
@@ -1,11 +1,11 @@
 ---
-course: Coding \& Cryptography
+course: Coding and Cryptography
 course_year: II
 question_number: 38
 tags:
 - II
 - '2018'
-- Coding \& Cryptography
+- Coding and Cryptography
 title: 'Paper 1, Section II, H '
 year: 2018
 ---

--- a/src/part-ii/2018-39.md
+++ b/src/part-ii/2018-39.md
@@ -1,11 +1,11 @@
 ---
-course: Coding \& Cryptography
+course: Coding and Cryptography
 course_year: II
 question_number: 39
 tags:
 - II
 - '2018'
-- Coding \& Cryptography
+- Coding and Cryptography
 title: 'Paper 2, Section II, H '
 year: 2018
 ---


### PR DESCRIPTION
Changed course titles from "Topics In Analysis" and "Coding \& Cryptography" in older questions to "Topics in Analysis" and "Coding and Cryptography" so that they aren't sorted as separate courses.