### PR TITLE
Fixed some clashes between IB and part II course names

### DIFF
--- a/src/part-ib/2009-47.md
+++ b/src/part-ib/2009-47.md
@@ -1,11 +1,11 @@
 ---
-course: Mathematical Methods
+course: Methods
 course_year: IB
 question_number: 47
 tags:
 - IB
 - '2009'
-- Mathematical Methods
+- Methods
 title: 'Paper 2, Section I, B '
 year: 2009
 ---

--- a/src/part-ib/2009-48.md
+++ b/src/part-ib/2009-48.md
@@ -1,11 +1,11 @@
 ---
-course: Mathematical Methods
+course: Methods
 course_year: IB
 question_number: 48
 tags:
 - IB
 - '2009'
-- Mathematical Methods
+- Methods
 title: 'Paper 4, Section I, B '
 year: 2009
 ---

--- a/src/part-ib/2009-49.md
+++ b/src/part-ib/2009-49.md
@@ -1,11 +1,11 @@
 ---
-course: Mathematical Methods
+course: Methods
 course_year: IB
 question_number: 49
 tags:
 - IB
 - '2009'
-- Mathematical Methods
+- Methods
 title: 'Paper 1, Section II, B '
 year: 2009
 ---

--- a/src/part-ib/2009-50.md
+++ b/src/part-ib/2009-50.md
@@ -1,11 +1,11 @@
 ---
-course: Mathematical Methods
+course: Methods
 course_year: IB
 question_number: 50
 tags:
 - IB
 - '2009'
-- Mathematical Methods
+- Methods
 title: 'Paper 2, Section II, B '
 year: 2009
 ---

--- a/src/part-ii/2019-57.md
+++ b/src/part-ii/2019-57.md
@@ -1,11 +1,11 @@
 ---
-course: Fluid Dynamics
+course: Fluid Dynamics II
 course_year: II
 question_number: 57
 tags:
 - II
 - '2019'
-- Fluid Dynamics
+- Fluid Dynamics II
 title: 'Paper 4, Section II, A '
 year: 2019
 ---

--- a/src/part-ii/2019-58.md
+++ b/src/part-ii/2019-58.md
@@ -1,11 +1,11 @@
 ---
-course: Fluid Dynamics
+course: Fluid Dynamics II
 course_year: II
 question_number: 58
 tags:
 - II
 - '2019'
-- Fluid Dynamics
+- Fluid Dynamics II
 title: 'Paper 2, Section II, A '
 year: 2019
 ---

--- a/src/part-ii/2019-59.md
+++ b/src/part-ii/2019-59.md
@@ -1,11 +1,11 @@
 ---
-course: Fluid Dynamics
+course: Fluid Dynamics II
 course_year: II
 question_number: 59
 tags:
 - II
 - '2019'
-- Fluid Dynamics
+- Fluid Dynamics II
 title: 'Paper 3, Section II, A '
 year: 2019
 ---

--- a/src/part-ii/2019-60.md
+++ b/src/part-ii/2019-60.md
@@ -1,11 +1,11 @@
 ---
-course: Fluid Dynamics
+course: Fluid Dynamics II
 course_year: II
 question_number: 60
 tags:
 - II
 - '2019'
-- Fluid Dynamics
+- Fluid Dynamics II
 title: 'Paper 1, Section II, A '
 year: 2019
 ---

--- a/src/part-ii/2021-58.md
+++ b/src/part-ii/2021-58.md
@@ -1,12 +1,12 @@
 ---
-course: Fluid Dynamics
+course: Fluid Dynamics II
 course_year: II
 question_number: 58
 tags:
 - II
 - '2021'
-- Fluid Dynamics
-title: Paper 1, Section II, 39A  II
+- Fluid Dynamics II
+title: Paper 1, Section II, 39A
 year: 2021
 ---
 

--- a/src/part-ii/2021-59.md
+++ b/src/part-ii/2021-59.md
@@ -1,12 +1,12 @@
 ---
-course: Fluid Dynamics
+course: Fluid Dynamics II
 course_year: II
 question_number: 59
 tags:
 - II
 - '2021'
-- Fluid Dynamics
-title: Paper 2, Section II, 39A  II
+- Fluid Dynamics II
+title: Paper 2, Section II, 39A
 year: 2021
 ---
 

--- a/src/part-ii/2021-60.md
+++ b/src/part-ii/2021-60.md
@@ -1,12 +1,12 @@
 ---
-course: Fluid Dynamics
+course: Fluid Dynamics II
 course_year: II
 question_number: 60
 tags:
 - II
 - '2021'
-- Fluid Dynamics
-title: Paper 3, Section II, 38A  II
+- Fluid Dynamics II
+title: Paper 3, Section II, 38A
 year: 2021
 ---
 

--- a/src/part-ii/2021-61.md
+++ b/src/part-ii/2021-61.md
@@ -1,12 +1,12 @@
 ---
-course: Fluid Dynamics
+course: Fluid Dynamics II
 course_year: II
 question_number: 61
 tags:
 - II
 - '2021'
-- Fluid Dynamics
-title: Paper 4, Section II, A  II
+- Fluid Dynamics II
+title: Paper 4, Section II, A
 year: 2021
 ---
 


### PR DESCRIPTION
Recent Fluids II exam q's have been categorised as "Fluid Dynamics", which not only separates them from older Qs, but also mixes them with the questions from the IB course.

Also, the 2009 IB methods questions were listed as "Mathematical Methods"; since this was also the name of a former part II course, I have renamed them to be part of Methods

---
(Btw, [not sure if you've noticed] there's also another irregularity with Electromagnetism and Markov Chains moving from Part II to Part IB with the 2004 tripos reform... but I don't think anything really needs to be done about this, since the content appears to be basically the same so it's fine for the questions to be mixed together.)