### PR TITLE
Remove comments boxes from tripos part pages

### DIFF
--- a/src/ia.njk
+++ b/src/ia.njk
@@ -17,8 +17,3 @@ description: "Part IA questions"
 <div class="tags">
   {% include "ia-course-list.njk" %}
 </div>
-
-
-
-{% set latestComments = '0' %}
-{% include "tripos-comments.njk" %}

--- a/src/ib.njk
+++ b/src/ib.njk
@@ -17,6 +17,3 @@ description: "Part IB questions"
 <div class="tags">
   {% include "ib-course-list.njk" %}
 </div>
-
-{% set latestComments = '0' %}
-{% include "tripos-comments.njk" %}

--- a/src/ii.njk
+++ b/src/ii.njk
@@ -17,6 +17,3 @@ description: "Part II questions"
 <div class="tags">
   {% include "ii-course-list.njk" %}
 </div>
-
-{% set latestComments = '0' %}
-{% include "tripos-comments.njk" %}


### PR DESCRIPTION
Since they don't work properly – see #228 .
I guess it is possible to make them work by setting it to show a set discussion for these pages but eh.