### PR TITLE
Set giscus to use og:title

### DIFF
--- a/src/includes/tripos-comments.njk
+++ b/src/includes/tripos-comments.njk
@@ -3,7 +3,7 @@
     data-repo-id="R_kgDOHNk5nA"
     data-category="Question comments"
     data-category-id="DIC_kwDOHNk5nM4CO-nf"
-    data-mapping="pathname"
+    data-mapping="og:title"
     data-reactions-enabled="1"
     data-emit-metadata="0"
     data-input-position="bottom"

--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -34,7 +34,7 @@
 
     <link rel="icon" type= “image/x-icon” href={{ "/images/favicon.ico" | url }}>
 
-    <meta property="og:title" content="{{  title or site.name | escape }}">
+    <meta property="og:title" content="{{ permalink or title or site.name | escape }}">
     <meta property="og:site_name" content="{{ site.name }}"/>
     <meta property="og:type" content="website"/>
     <meta property="og:url" content="{{ site.url + page.url }}"/>

--- a/src/layouts/post.njk
+++ b/src/layouts/post.njk
@@ -1,5 +1,7 @@
 ---
 layout: base.njk
+eleventyComputed:
+  permalink: part-{{ course_year | lower }}/{{ year }}-{{ question_number }}/
 ---
 
 <article class="post">


### PR DESCRIPTION
And also set `og:title` to be based off the permalink for pages that have them, and set the permalink for question pages to be the current pathname format.

This makes the linking between question and GH discussion stable under URL changes, solving #243 ...