### PR TITLE
Add scrollbars on overwide KaTeX blocks.

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -38,3 +38,8 @@
 	margin-top: 0;
 }
 
+.tags {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+}

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -22,7 +22,8 @@
   padding-left: 1rem;
   padding-right: 1rem;
   min-width: 0;
-  max-width: 100%;
+  width: 100%;
+  max-width: 48.75rem;
   margin-left: auto;
   margin-right: auto;
 }
@@ -35,9 +36,5 @@
 .switcher img {
 	height:100%;
 	margin-top: 0;
-}
-
-.katex-block {
-	overflow-x: scroll;
 }
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -22,7 +22,7 @@
   padding-left: 1rem;
   padding-right: 1rem;
   min-width: 0;
-  max-width: 48.75rem;
+  max-width: 100%;
   margin-left: auto;
   margin-right: auto;
 }
@@ -35,5 +35,9 @@
 .switcher img {
 	height:100%;
 	margin-top: 0;
+}
+
+.katex-block {
+	overflow-x: scroll;
 }
 

--- a/src/css/post.css
+++ b/src/css/post.css
@@ -19,6 +19,12 @@
 
 .post__content {
   word-wrap: break-word;
+  /* for some reason without this the posts end up too wide
+  even with `.katex-block` set to scroll,
+  and even though no post actually gets a horizontal scrollbar? */
+  overflow-x: scroll;
+  /* stop random vertical scrollbars */
+  overflow-y: hidden;
 }
 
 .post__aside {
@@ -53,4 +59,9 @@
 .post__pagination span {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
+}
+
+
+.katex-block {
+	overflow-x: scroll;
 }

--- a/src/includes/course-list.njk
+++ b/src/includes/course-list.njk
@@ -1,14 +1,21 @@
 <h4>Current</h4>
+
+<div class="tags">
 {% for course in collections.sortingData[triposPart].currentCourses%}
   {% set courseUrl %}/courses/{{ course }}/{% endset %}
 
   <a href="{{ courseUrl | url }}" class="post-tag">{{ course }}</a>
 
 {% endfor %}
+</div>
+
 <h4>Discontinued</h4>
+
+<div class="tags">
 {% for course in collections.sortingData[triposPart].oldCourses %}
   {% set courseUrl %}/courses/{{ course }}/{% endset %}
 
   <a href="{{ courseUrl | url }}" class="post-tag">{{ course }}</a>
 
 {% endfor %}
+</div>

--- a/src/includes/posts-list.njk
+++ b/src/includes/posts-list.njk
@@ -1,9 +1,7 @@
 <div>
 
-{{ rightFloat | safe}}
-
-<div class="tags" style="float:left">
 <h3>Jump to {{ group_type }}</h3>
+<div class="tags">
 {% for group in groupslist %}
 	{% if postslist[group].length > 0 %}
 		<a href="#{{ group | url }}" class="post-tag">{{ group }}</a>

--- a/src/index.md
+++ b/src/index.md
@@ -9,5 +9,3 @@ An archive of questions from the [Cambridge Mathematics Tripos](https://www.math
 
 {% set latestComments = '50' %}
 {% include "tripos-comments.njk" %}
-
-*For older comments, see [GitHub discussions](https://github.com/tripos-education/maths-tripos-questions/discussions).*

--- a/src/tripos-part.njk
+++ b/src/tripos-part.njk
@@ -19,10 +19,8 @@ eleventyComptuted:
 </div>
 
 <h3>By Course</h3>
-<div class="tags">
   {% set triposPart = part %}
   {% include "course-list.njk" %}
-</div>
 
 
 


### PR DESCRIPTION
As a fix to #339, as overwide KaTeX blocks seem to be the root course of this issue...